### PR TITLE
playerX cannot move for playerO

### DIFF
--- a/Frontend/src/components/compound/OnlineMultiplayerBoard/data.ts
+++ b/Frontend/src/components/compound/OnlineMultiplayerBoard/data.ts
@@ -1,8 +1,8 @@
-import { Cell, Game } from "../../../lib/services/game/types";
+import { Cell, Game, Player } from "../../../lib/services/game/types";
 import { gameService } from "../../../lib/services/game/service";
 import { useEffect, useState } from "react";
 
-export const useBoardData = (selectedGame: Game) => {
+export const useBoardData = (selectedGame: Game, onlinePlayer: Player) => {
   const [game, setGame] = useState<Game>(selectedGame);
   const [poller, setPoller] = useState<number>(0);
 
@@ -17,8 +17,15 @@ export const useBoardData = (selectedGame: Game) => {
   }, [poller]);
 
   const handleClick = async (cell: Cell) => {
-    const data = await gameService().makeGameMove(cell, selectedGame.id);
-    setGame(data.game);
+    console.log("current player", game.currentPlayer);
+    console.log("online player", onlinePlayer);
+
+    if (game.currentPlayer?.name === onlinePlayer.name) {
+      console.log("passed check");
+
+      const data = await gameService().makeGameMove(cell, selectedGame.id);
+      setGame(data.game);
+    }
   };
 
   const handleReset = async (id: string) => {

--- a/Frontend/src/components/compound/OnlineMultiplayerBoard/data.ts
+++ b/Frontend/src/components/compound/OnlineMultiplayerBoard/data.ts
@@ -17,12 +17,7 @@ export const useBoardData = (selectedGame: Game, onlinePlayer: Player) => {
   }, [poller]);
 
   const handleClick = async (cell: Cell) => {
-    console.log("current player", game.currentPlayer);
-    console.log("online player", onlinePlayer);
-
     if (game.currentPlayer?.name === onlinePlayer.name) {
-      console.log("passed check");
-
       const data = await gameService().makeGameMove(cell, selectedGame.id);
       setGame(data.game);
     }

--- a/Frontend/src/components/compound/OnlineMultiplayerBoard/index.tsx
+++ b/Frontend/src/components/compound/OnlineMultiplayerBoard/index.tsx
@@ -5,8 +5,12 @@ import { OnlineBoardProps } from "./types";
 const OnlineMultiplayerBoard = ({
   selectedGame,
   setMode,
+  onlinePlayer,
 }: OnlineBoardProps) => {
-  const { handleClick, handleReset, game } = useBoardData(selectedGame);
+  const { handleClick, handleReset, game } = useBoardData(
+    selectedGame,
+    onlinePlayer
+  );
 
   if (game) {
     return (

--- a/Frontend/src/components/compound/OnlineMultiplayerBoard/types.ts
+++ b/Frontend/src/components/compound/OnlineMultiplayerBoard/types.ts
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction } from "react";
 import { Mode } from "../../pages/Start/types";
-import { Cell, Game } from "../../../lib/services/game/types";
+import { Cell, Game, Player } from "../../../lib/services/game/types";
 
 export type Fields = {
   game: Game;
@@ -12,4 +12,5 @@ export type Fields = {
 export type OnlineBoardProps = {
   setMode: Dispatch<SetStateAction<Mode>>;
   selectedGame: Game;
+  onlinePlayer: Player;
 };

--- a/Frontend/src/components/compound/OnlineMultiplayerLobby/component.tsx
+++ b/Frontend/src/components/compound/OnlineMultiplayerLobby/component.tsx
@@ -6,10 +6,15 @@ const Component = ({
   games,
   handleJoinGame,
   selectedGame,
+  onlinePlayer,
 }: Fields) => {
   if (selectedGame) {
     return (
-      <OnlineMultiplayerBoard setMode={setMode} selectedGame={selectedGame} />
+      <OnlineMultiplayerBoard
+        setMode={setMode}
+        selectedGame={selectedGame}
+        onlinePlayer={onlinePlayer}
+      />
     );
   }
 

--- a/Frontend/src/components/compound/OnlineMultiplayerLobby/index.tsx
+++ b/Frontend/src/components/compound/OnlineMultiplayerLobby/index.tsx
@@ -10,6 +10,7 @@ const OnlineMultiplayerLobby = ({ onlinePlayer, setMode }: LobbyProps) => {
       games={games}
       selectedGame={selectedGame}
       handleJoinGame={handleJoinGame}
+      onlinePlayer={onlinePlayer}
     />
   );
 };

--- a/Frontend/src/components/compound/OnlineMultiplayerLobby/types.ts
+++ b/Frontend/src/components/compound/OnlineMultiplayerLobby/types.ts
@@ -7,6 +7,7 @@ export type Fields = {
   games: Game[] | undefined;
   selectedGame: Game | undefined;
   handleJoinGame: (id: string) => void;
+  onlinePlayer: Player;
 };
 
 export type LobbyProps = {


### PR DESCRIPTION
## Purpose
players could move for both X and O turns so now they can't! Once I have a db set up, I will check this based on id but for now it is checked based on names... (bad)
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 65ac0fed21ae4215aa53759a338f7278ecd12627  | 
|--------|--------|

### Summary:
Ensure only the current player can make a move in online multiplayer by passing and checking `onlinePlayer` in relevant components and updating `useBoardData` to check against `game.currentPlayer`.

**Key points**:
- Updated `useBoardData` in `Frontend/src/components/compound/OnlineMultiplayerBoard/data.ts` to accept `onlinePlayer` and check if the current player matches `onlinePlayer` before making a move.
- Modified `OnlineMultiplayerBoard` component in `Frontend/src/components/compound/OnlineMultiplayerBoard/index.tsx` to pass `onlinePlayer` to `useBoardData`.
- Updated `OnlineBoardProps` in `Frontend/src/components/compound/OnlineMultiplayerBoard/types.ts` to include `onlinePlayer`.
- Modified `Component` in `Frontend/src/components/compound/OnlineMultiplayerLobby/component.tsx` to pass `onlinePlayer` to `OnlineMultiplayerBoard`.
- Updated `OnlineMultiplayerLobby` component in `Frontend/src/components/compound/OnlineMultiplayerLobby/index.tsx` to pass `onlinePlayer` to `Component`.
- Updated `Fields` and `LobbyProps` in `Frontend/src/components/compound/OnlineMultiplayerLobby/types.ts` to include `onlinePlayer`.
- Updated `useBoardData` in `Frontend/src/components/compound/OnlineMultiplayerBoard/data.ts` to check if `game.currentPlayer` matches `onlinePlayer` before making a move.
- Removed debug `console.log` statements from `handleClick` function in `useBoardData`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->