### PR TITLE
Sc/home button repositioning

### DIFF
--- a/Frontend/src/components/compound/MultiplayerBoard/component.tsx
+++ b/Frontend/src/components/compound/MultiplayerBoard/component.tsx
@@ -40,7 +40,7 @@ const Component = ({
           <div>{gameState.winner.playerO}</div>
         </div>
       </div>
-      <div className="flex flex-row items-center justify-center gap-4">
+      <div className="flex flex-row items-center gap-4">
         <button
           onClick={() => setMode(0)}
           className="btn btn-wide h-fit btn-warning font-bold text-2xl uppercase"

--- a/Frontend/src/components/compound/MultiplayerBoard/component.tsx
+++ b/Frontend/src/components/compound/MultiplayerBoard/component.tsx
@@ -11,12 +11,6 @@ const Component = ({
 }: Fields) => {
   return (
     <div className="flex flex-col items-center">
-      <button
-        onClick={() => setMode(0)}
-        className="btn btn-warning top-20 absolute left-20"
-      >
-        Home
-      </button>
       <div className={s.boardContainer}>
         {board.map((cell, i) => (
           <button
@@ -46,13 +40,21 @@ const Component = ({
           <div>{gameState.winner.playerO}</div>
         </div>
       </div>
-      <button
-        className="btn btn-wide h-fit btn-warning font-bold text-2xl uppercase"
-        onClick={handleReset}
-        disabled={gameState.currentGameFinished ? false : true}
-      >
-        play again
-      </button>
+      <div className="flex flex-row items-center justify-center gap-4">
+        <button
+          onClick={() => setMode(0)}
+          className="btn btn-wide h-fit btn-warning font-bold text-2xl uppercase"
+        >
+          Home
+        </button>
+        <button
+          className="btn btn-wide h-fit btn-warning font-bold text-2xl uppercase"
+          onClick={handleReset}
+          disabled={gameState.currentGameFinished ? false : true}
+        >
+          play again
+        </button>
+      </div>
     </div>
   );
 };

--- a/Frontend/src/components/compound/OnlineMultiplayerBoard/component.tsx
+++ b/Frontend/src/components/compound/OnlineMultiplayerBoard/component.tsx
@@ -46,7 +46,7 @@ const Component = ({
           <div>{game.winState.playerO}</div>
         </div>
       </div>
-      <div className="flex flex-row items-center justify-center gap-4">
+      <div className="flex flex-row items-center gap-4">
         <button
           onClick={handleLeaveGame}
           className="btn btn-wide h-fit btn-warning font-bold text-2xl uppercase"

--- a/Frontend/src/components/compound/OnlineMultiplayerBoard/component.tsx
+++ b/Frontend/src/components/compound/OnlineMultiplayerBoard/component.tsx
@@ -9,12 +9,6 @@ const Component = ({
 }: Fields) => {
   return (
     <div className="flex flex-col items-center">
-      <button
-        onClick={handleLeaveGame}
-        className="btn btn-warning top-20 absolute left-20"
-      >
-        Lobby
-      </button>
       <div className={s.boardContainer}>
         {game.board.map((cell, i) => (
           <button
@@ -52,13 +46,21 @@ const Component = ({
           <div>{game.winState.playerO}</div>
         </div>
       </div>
-      <button
-        className="btn btn-wide h-fit btn-warning font-bold text-2xl uppercase"
-        onClick={handleReset}
-        disabled={game.winState.currentGameFinished ? false : true}
-      >
-        play again
-      </button>
+      <div className="flex flex-row items-center justify-center gap-4">
+        <button
+          onClick={handleLeaveGame}
+          className="btn btn-wide h-fit btn-warning font-bold text-2xl uppercase"
+        >
+          Lobby
+        </button>
+        <button
+          className="btn btn-wide h-fit btn-warning font-bold text-2xl uppercase"
+          onClick={handleReset}
+          disabled={game.winState.currentGameFinished ? false : true}
+        >
+          play again
+        </button>
+      </div>
     </div>
   );
 };

--- a/Frontend/src/components/compound/OnlineMultiplayerLobby/component.tsx
+++ b/Frontend/src/components/compound/OnlineMultiplayerLobby/component.tsx
@@ -24,14 +24,15 @@ const Component = ({
   }
 
   return (
-    <div className="h-[100vh] flex flex-col gap-36 p-10">
-      <button
-        onClick={() => setMode(0)}
-        className="btn btn-warning top-20 absolute left-20"
-      >
-        Home
-      </button>
-      <div className="uppercase text-8xl text-white font-extrabold">lobby</div>
+    <div className="h-[100vh] flex flex-col gap-24 p-10">
+      <div className="flex flex-row items-center gap-10">
+        <div className="uppercase text-8xl text-white font-extrabold">
+          lobby
+        </div>
+        <button onClick={() => setMode(0)} className="btn btn-warning">
+          Home
+        </button>
+      </div>
 
       <div className="flex flex-row gap-6 flex-wrap justify-center">
         <div className="card w-96 bg-neutral text-neutral-content">

--- a/Frontend/src/components/compound/SingleplayerBoard/component.tsx
+++ b/Frontend/src/components/compound/SingleplayerBoard/component.tsx
@@ -11,12 +11,6 @@ const Component = ({
 }: Fields) => {
   return (
     <div className="flex flex-col items-center">
-      <button
-        onClick={() => setMode(0)}
-        className="btn btn-warning top-20 absolute left-20"
-      >
-        Home
-      </button>
       <div className={s.boardContainer}>
         {board.map((cell, i) => (
           <button
@@ -46,13 +40,21 @@ const Component = ({
           <div>{gameState.winner.playerO}</div>
         </div>
       </div>
-      <button
-        className="btn btn-wide h-fit btn-warning font-bold text-2xl uppercase"
-        onClick={handleReset}
-        disabled={gameState.currentGameFinished ? false : true}
-      >
-        play again
-      </button>
+      <div className="flex flex-row items-center gap-4">
+        <button
+          onClick={() => setMode(0)}
+          className="btn btn-wide h-fit btn-warning font-bold text-2xl uppercase"
+        >
+          Home
+        </button>
+        <button
+          className="btn btn-wide h-fit btn-warning font-bold text-2xl uppercase"
+          onClick={handleReset}
+          disabled={gameState.currentGameFinished ? false : true}
+        >
+          play again
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d1429b143e05c1a64eaa62fe2dc74dad0cbcf7aa  | 
|--------|--------|

### Summary:
Repositioned 'Home' and 'Lobby' buttons in various components for improved UI layout.

**Key points**:
- Repositioned 'Home' button in `Frontend/src/components/compound/MultiplayerBoard/component.tsx` to be next to the 'Play Again' button.
- Repositioned 'Lobby' button in `Frontend/src/components/compound/OnlineMultiplayerBoard/component.tsx` to be next to the 'Play Again' button.
- Repositioned 'Home' button in `Frontend/src/components/compound/OnlineMultiplayerLobby/component.tsx` to be next to the 'Lobby' title.
- Repositioned 'Home' button in `Frontend/src/components/compound/SingleplayerBoard/component.tsx` to be next to the 'Play Again' button.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->