### PR TITLE
styling now responsive

### DIFF
--- a/Frontend/src/components/compound/SingleplayerBoard/component.tsx
+++ b/Frontend/src/components/compound/SingleplayerBoard/component.tsx
@@ -11,11 +11,11 @@ const Component = ({
 }: Fields) => {
   return (
     <div className="flex flex-col items-center">
-      <div className={s.boardContainer}>
+      <div className="grid grid-cols-3 aspect-square lg:w-[79%] w-[80%] ">
         {board.map((cell, i) => (
           <button
             key={i}
-            className={s.boardButton}
+            className={`${s.boardButton} aspect-square `}
             onClick={() => handleClick(cell)}
             disabled={
               gameState.currentGameFinished ? true : cell.value ? true : false

--- a/Frontend/src/components/compound/SingleplayerBoard/styles.module.css
+++ b/Frontend/src/components/compound/SingleplayerBoard/styles.module.css
@@ -1,12 +1,15 @@
 .boardContainer {
-  display: flex;
-  flex-wrap: wrap;
-  width: 650px;
+  /* display: flex; */
+  /* flex-wrap: wrap; */
+  /* width: 100%; */
+  /* aspect-ratio: 1 / 1; */
+  /* min-width: 0; */
+  /* max-width: 600px; */
 }
 
 .boardButton {
-  flex: 1 0 calc(33.333% - 8px); /* 33.333% width with 8px margin */
-  height: 200px;
+  /* flex: 1 0 calc(33.333% - 8px); 33.333% width with 8px margin */
+  /* height: calc(33%); */
   background-color: white;
   border-radius: 20px;
   margin: 4px;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9f557edca2a9080f0623dd11b26d4057403416e3  | 
|--------|--------|

### Summary:
Made SingleplayerBoard component responsive by switching from flexbox to CSS grid layout.

**Key points**:
- Updated `Frontend/src/components/compound/SingleplayerBoard/component.tsx` to use CSS grid for responsive design.
- Modified `div` containing the board to use `grid grid-cols-3 aspect-square lg:w-[79%] w-[80%]` classes.
- Updated `button` elements to include `aspect-square` class for maintaining square aspect ratio.
- Commented out old flexbox styles in `Frontend/src/components/compound/SingleplayerBoard/styles.module.css` for `.boardContainer` and `.boardButton`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->